### PR TITLE
Inaccurate ping fix

### DIFF
--- a/src/mairu.go
+++ b/src/mairu.go
@@ -82,7 +82,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	eventEmitter.Use("message", emitter.Void)
 	eventEmitter.On("message", func(ev *emitter.Event) {
 		route(ev)
 	})

--- a/src/routes.go
+++ b/src/routes.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"time"
+	"math"
 )
 
 func s(a string) *string {
@@ -12,5 +14,6 @@ func s(a string) *string {
 // PongRoute ...
 func PongRoute(event eventInfo) (bool, *string) {
 	sent, _ := event.message.Timestamp.Parse()
-	return false, s(fmt.Sprintf("%fs", sent.Sub(event.received).Seconds()))
+	elapsed := math.Abs(float64(time.Since(sent) / time.Millisecond))
+	return false, s(fmt.Sprintf("%vms", elapsed))
 }


### PR DESCRIPTION
Measures elapsed time in milliseconds and uses the absolute value to prevent negative values.